### PR TITLE
Don't raise for status when creating a blueprint

### DIFF
--- a/stackdio/client/blueprint.py
+++ b/stackdio/client/blueprint.py
@@ -48,7 +48,7 @@ class BlueprintMixin(HttpMixin):
                         self.get_formula(formula_id),
                         component["id"][1])
 
-        return self._post(endpoint, data=json.dumps(blueprint), jsonify=True)
+        return self._post(endpoint, data=json.dumps(blueprint), jsonify=True, raise_for_status=False)
 
     @endpoint("blueprints/")
     def list_blueprints(self):


### PR DESCRIPTION
This is annoying in the CLI, because when you create a blueprint and it doesn't work, you don't know what went wrong.  With this fix, you actually see the error message.